### PR TITLE
change from overwrite drop to append drop (junglegrass)

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -4,3 +4,4 @@ walls
 fire
 beds
 doors
+bonemeal?

--- a/farming.lua
+++ b/farming.lua
@@ -1,3 +1,35 @@
+local function add_drop(nodename, drop_table)
+
+	-- does node exist?
+	if not minetest.registered_nodes[nodename] then return end
+
+	-- get existing drops
+	local drops = minetest.registered_nodes[nodename].drop
+
+	-- if single item string then apend to end of new drop_table
+	if type(drops) == "string" then print ("== string")
+
+		table.insert(drop_table.items, {items = {drops}})
+	elseif type(drops) == "table" then print ("== table")
+
+		-- apend existing drops to new drop_table
+		for _, item in ipairs(drops.items) do
+			table.insert(drop_table.items, item)
+		end
+
+		-- use new max_items or default to current
+		drop_table.max_items = drop_table.max_items or drops.max_items
+	end
+
+	-- override node with new drops
+	minetest.override_item(nodename, {drop = drop_table})
+end
+
+
+
+
+
+
 ----------------------------------------------------------
 -- Bottle Gourd
 
@@ -69,23 +101,29 @@ minetest.register_craft({
 	burntime = 1,
 })
 
-
-
-
-
-
-
-
+if minetest.registered_nodes["default:junglegrass"].drop == nil then
+	add_drop("default:junglegrass", {
+		max_items = 1,
+		items = {
+			{items = {"farming:seed_cotton"}, rarity = 8},
+			{items = {"default:junglegrass"}}
+	}
+})
+end
 
 ------------
 --Collect wild seeds
 --a tropical species so...
-
-minetest.override_item("default:junglegrass", {drop = {
-	max_items = 1,
+add_drop("default:junglegrass", {
 	items = {
-		{items = {'farming:seed_cotton'},rarity = 8},
-		{items = {'earthbuild:seed_bottlegourd'},rarity = 8},
-		{items = {'default:junglegrass'}},
+		{items = {"earthbuild:seed_bottlegourd"}, rarity = 8},
 	}
-}})
+})
+
+minetest.log(dump(minetest.registered_nodes["default:junglegrass"].drop))
+
+minetest.log("Adding bonemeal support for ")
+bonemeal:add_crop({
+	{"earthbuild:bottlegourd_", 8, "earthbuild:seed_bottlegourd"}
+})
+


### PR DESCRIPTION
When used with farming redo, if your mod loads first, gourd seed drop is overwritten, if TenPlus1's mod loads first, rice seed drop is overwritten. This code change appends to existing drops instead of overwriting, so it matters not which happens first.